### PR TITLE
Fix mongod service start command

### DIFF
--- a/README.mkd
+++ b/README.mkd
@@ -61,7 +61,7 @@ Create a directory called "log" under the project folder. Make sure that the ser
 
 If you don't already have it, [install MongoDB](http://docs.mongodb.org/manual/installation/). Our current data dump requires MongoDB version 2.6 or later. After installing Mongo, run the mongo daemon with:
 
-    sudo mongod
+    sudo service mongod start
 
 #### Put some texts in your database:
 


### PR DESCRIPTION
Using the installation instructions for Ubuntu from the [official MongoDB installation page](https://docs.mongodb.com/manual/tutorial/install-mongodb-on-ubuntu/).

This works for me, while the command that exists does not work for me.